### PR TITLE
Add testing environment with simple test example

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,10 @@
     "build": "ionic-app-scripts build",
     "lint": "ionic-app-scripts lint",
     "ionic:build": "ionic-app-scripts build",
-    "ionic:serve": "ionic-app-scripts serve"
+    "ionic:serve": "ionic-app-scripts serve",
+    "test": "karma start ./test-config/karma.conf.js",
+    "test-ci": "karma start ./test-config/karma.conf.js --single-run",
+    "test-coverage": "karma start ./test-config/karma.conf.js --coverage"
   },
   "dependencies": {
     "@angular/animations": "5.2.9",
@@ -32,7 +35,26 @@
     "zone.js": "0.8.20"
   },
   "devDependencies": {
+    "@angular/cli": "1.4.8",
     "@ionic/app-scripts": "3.1.8",
+    "@types/jasmine": "^2.5.41",
+    "@types/node": "^8.0.45",
+    "angular2-template-loader": "^0.6.2",
+    "html-loader": "^0.5.1",
+    "istanbul-instrumenter-loader": "^3.0.0",
+    "jasmine": "^2.5.3",
+    "jasmine-spec-reporter": "^4.1.0",
+    "karma": "^1.5.0",
+    "karma-chrome-launcher": "^2.0.0",
+    "karma-coverage-istanbul-reporter": "^1.3.0",
+    "karma-jasmine": "^1.1.0",
+    "karma-jasmine-html-reporter": "^0.2.2",
+    "karma-sourcemap-loader": "^0.3.7",
+    "karma-webpack": "^2.0.3",
+    "null-loader": "^0.1.1",
+    "protractor": "^5.1.1",
+    "ts-loader": "^3.0.3",
+    "ts-node": "^3.0.2",
     "typescript": "~2.6.2"
   },
   "description": "An Ionic project"

--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -1,0 +1,6 @@
+// @TODO Replace this test with something useful
+describe('An example test', () => {
+  it('should do nothing', () => {
+    expect(true).toBeTruthy();
+  });
+});

--- a/test-config/karma-test-shim.js
+++ b/test-config/karma-test-shim.js
@@ -1,0 +1,21 @@
+Error.stackTraceLimit = Infinity;
+
+require('core-js/es6');
+require('core-js/es7/reflect');
+
+require('zone.js/dist/zone');
+require('zone.js/dist/long-stack-trace-zone');
+require('zone.js/dist/proxy');
+require('zone.js/dist/sync-test');
+require('zone.js/dist/jasmine-patch');
+require('zone.js/dist/async-test');
+require('zone.js/dist/fake-async-test');
+
+var appContext = require.context('../src', true, /\.spec\.ts/);
+
+appContext.keys().forEach(appContext);
+
+var testing = require('@angular/core/testing');
+var browser = require('@angular/platform-browser-dynamic/testing');
+
+testing.TestBed.initTestEnvironment(browser.BrowserDynamicTestingModule, browser.platformBrowserDynamicTesting());

--- a/test-config/karma.conf.js
+++ b/test-config/karma.conf.js
@@ -1,0 +1,84 @@
+var webpackConfig = require('./webpack.test.js');
+
+// Karma configuration
+module.exports = function(config) {
+  config.set({
+    // Base path that will be used to resolve all patterns (eg. files, exclude)
+    basePath: '../',
+
+    // Frameworks to use
+    // Available frameworks: https://npmjs.org/browse/keyword/karma-adapter
+    frameworks: ['jasmine'],
+
+    // List of files / patterns to load in the browser
+    files: [
+      {
+        pattern: './test-config/karma-test-shim.js',
+        watched: true
+      },
+      {
+        pattern: './src/assets/**/*',
+        watched: false,
+        included: false,
+        served: true,
+        nocache: false
+      }
+    ],
+
+    proxies: {
+      '/assets/': '/base/src/assets/'
+    },
+
+    // Preprocess matching files before serving them to the browser
+    // Available preprocessors: https://npmjs.org/browse/keyword/karma-preprocessor
+    preprocessors: {
+      './test-config/karma-test-shim.js': ['webpack', 'sourcemap']
+    },
+
+    webpack: webpackConfig,
+
+    webpackMiddleware: {
+      stats: 'errors-only'
+    },
+
+    webpackServer: {
+      noInfo: true
+    },
+
+    browserConsoleLogOptions: {
+      level: 'log',
+      format: '%b %T: %m',
+      terminal: true
+    },
+
+    coverageIstanbulReporter: {
+      reports: [ 'html', 'lcovonly' ],
+      fixWebpackSourcePaths: true
+    },
+
+    // Test results reporter to use
+    // Available reporters: https://npmjs.org/browse/keyword/karma-reporter
+    reporters: config.coverage ? ['kjhtml', 'dots', 'coverage-istanbul'] : ['kjhtml', 'dots'],
+
+    // Web server port
+    port: 9876,
+
+    // Enable / disable colors in the output (reporters and logs)
+    colors: true,
+
+    // Level of logging
+    // Possible values: config.LOG_DISABLE || config.LOG_ERROR || config.LOG_WARN || config.LOG_INFO || config.LOG_DEBUG
+    logLevel: config.LOG_INFO,
+
+    // Enable / disable watching file and executing tests whenever any file changes
+    autoWatch: true,
+
+    // Start these browsers
+    // Available browser launchers: https://npmjs.org/browse/keyword/karma-launcher
+    browsers: ['Chrome'],
+
+    // Continuous Integration mode
+    // If true, Karma captures browsers, runs the tests and exits
+    singleRun: false
+  });
+};

--- a/test-config/webpack.test.js
+++ b/test-config/webpack.test.js
@@ -1,0 +1,50 @@
+var webpack = require('webpack');
+var path = require('path');
+
+module.exports = {
+  devtool: 'inline-source-map',
+
+  resolve: {
+    extensions: ['.ts', '.js']
+  },
+
+  module: {
+    rules: [{
+        test: /\.ts$/,
+        loaders: [{
+          loader: 'ts-loader'
+        }, 'angular2-template-loader']
+      },
+      {
+        test: /.+\.ts$/,
+        exclude: /(index.ts|mocks.ts|\.spec\.ts$)/,
+        loader: 'istanbul-instrumenter-loader',
+        enforce: 'post',
+        query: {
+          esModules: true
+        }
+      },
+      {
+        test: /\.html$/,
+        loader: 'html-loader?attrs=false'
+      },
+      {
+        test: /\.(png|jpe?g|gif|svg|woff|woff2|ttf|eot|ico)$/,
+        loader: 'null-loader'
+      }
+    ]
+  },
+
+  plugins: [
+    new webpack.ContextReplacementPlugin(
+      // The (\\|\/) piece accounts for path separators in *nix and Windows
+      /(ionic-angular)|(angular(\\|\/)core(\\|\/)@angular)/,
+      root('./src'), // location of your src
+      {} // a map of your routes
+    )
+  ]
+};
+
+function root(localPath) {
+  return path.resolve(__dirname, localPath);
+}


### PR DESCRIPTION
Configures a testing environment using Karma and Jasmine and adds a simple test example:
```ts
// @TODO Replace this test with something useful
describe('An example test', () => {
  it('should do nothing', () => {
    expect(true).toBeTruthy();
  });
});

```

**Testing commands:**
```js
"test": "karma start ./test-config/karma.conf.js",
"test-ci": "karma start ./test-config/karma.conf.js --single-run",
"test-coverage": "karma start ./test-config/karma.conf.js --coverage"
```

Configuration inspired by [the official testing example by Ionic](https://github.com/ionic-team/ionic-unit-testing-example).