### PR TITLE
Replace User functionality with Nurse provider

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -11,6 +11,7 @@ import { AngularFireModule } from 'angularfire2';
 import { AngularFireAuthModule } from 'angularfire2/auth';
 import { AngularFirestoreModule } from 'angularfire2/firestore';
 import firebaseConfig from '../config/firebase.config';
+import { NurseProvider } from '../providers/nurse/nurse';
 
 @NgModule({
   declarations: [
@@ -33,6 +34,7 @@ import firebaseConfig from '../config/firebase.config';
     StatusBar,
     SplashScreen,
     { provide: ErrorHandler, useClass: IonicErrorHandler },
+    NurseProvider,
   ],
 })
 export class AppModule {}

--- a/src/models/nurse.ts
+++ b/src/models/nurse.ts
@@ -1,0 +1,8 @@
+import { DocumentReference } from '@firebase/firestore-types';
+
+export interface Nurse {
+  $id?: string;
+  name: string;
+  age: number;
+  roomRef: DocumentReference;
+}

--- a/src/models/user.ts
+++ b/src/models/user.ts
@@ -1,5 +1,0 @@
-export interface User {
-  $id?: string;
-  name: string;
-  age: number;
-}

--- a/src/pages/home/home.html
+++ b/src/pages/home/home.html
@@ -4,7 +4,7 @@
       Heartbeat
     </ion-title>
     <ion-buttons end>
-      <button ion-button icon-only (click)="addUserPrompt()">
+      <button ion-button icon-only (click)="addNursePrompt()">
         <ion-icon name="add"></ion-icon>
       </button>
     </ion-buttons>
@@ -13,16 +13,17 @@
 
 <ion-content>
   <ion-list>
-    <ion-item-sliding #item *ngFor="let user of users | async">
-      <ion-item (click)="updateUserPrompt(user)">
+    <ion-item-sliding #item *ngFor="let nurse of nurses | async">
+      <ion-item (click)="updateNursePrompt(nurse)">
         <ion-avatar item-start>
-          <img src="http://i.pravatar.cc/150?u={{user.$id}}">
+          <img src="http://i.pravatar.cc/150?u={{nurse.$id}}">
         </ion-avatar>
-        <h2>{{user.name}}</h2>
-        <p>Age: {{user.age}}</p>
+        <h2>{{nurse.name}}</h2>
+        <p>Age: {{nurse.age}}</p>
+        <p>Room: {{nurse.room}}</p>
       </ion-item>
       <ion-item-options side="right">
-        <button ion-button color="danger" (click)="removeUser(user)">
+        <button ion-button color="danger" (click)="removeNurse(nurse)">
           <ion-icon name="trash"></ion-icon>
           Remove
         </button>

--- a/src/pages/home/home.ts
+++ b/src/pages/home/home.ts
@@ -1,7 +1,7 @@
 import { Component } from '@angular/core';
 import { NavController, AlertController } from 'ionic-angular';
-import { AngularFirestore, AngularFirestoreCollection } from 'angularfire2/firestore';
-import { User } from '../../models/user';
+import { Nurse } from '../../models/nurse';
+import { NurseProvider } from '../../providers/nurse/nurse';
 import { Observable } from 'rxjs/Observable';
 
 @Component({
@@ -9,89 +9,22 @@ import { Observable } from 'rxjs/Observable';
   templateUrl: 'home.html',
 })
 export class HomePage {
+  public nurses: Observable<Nurse[]>;
 
-  public usersCollection: AngularFirestoreCollection<User>;
-  public users: Observable<User[]>;
-
-  constructor(public navCtrl: NavController, public alertCtrl: AlertController, public fireStore: AngularFirestore) {
-    this.usersCollection = fireStore.collection<User>('/users');
-    this.users = this.usersCollection.snapshotChanges().map((actions) => actions.map((action) => ({
-      $id: action.payload.doc.id, ...action.payload.doc.data() as User,
-    })));
+  constructor(public navCtrl: NavController, public alertCtrl: AlertController, public nurseProvider: NurseProvider) {
+    this.nurses = nurseProvider.getNurses();
   }
 
-  public addUserPrompt() {
-    const prompt = this.alertCtrl.create({
-      title: 'Add User',
-      message: 'Add a new user.',
-      inputs: [
-        {
-          name: 'name',
-          placeholder: 'Name',
-        },
-        {
-          name: 'age',
-          placeholder: 'Age',
-          type: 'number',
-        },
-      ],
-      buttons: [
-        {
-          text: 'Cancel',
-        },
-        {
-          text: 'Add',
-          handler: ({ name, age }) => this.addUser({ name, age: +age }),
-        },
-      ],
-    });
-    prompt.present();
+  public addNursePrompt() {
+    this.nurseProvider.addNursePrompt();
   }
 
-  public updateUserPrompt(user: User) {
-    const prompt = this.alertCtrl.create({
-      title: 'Update User',
-      message: 'Update user data.',
-      inputs: [
-        {
-          name: 'name',
-          placeholder: user.name,
-        },
-        {
-          name: 'age',
-          placeholder: String(user.age),
-          type: 'number',
-        },
-      ],
-      buttons: [
-        {
-          text: 'Cancel',
-        },
-        {
-          text: 'Update',
-          handler: ({ name, age }) => this.updateUser(user, {
-            name: name || user.name,
-            age: +age || user.age,
-          }),
-        },
-      ],
-    });
-    prompt.present();
+  public updateNursePrompt(nurse: Nurse) {
+    this.nurseProvider.updateNursePrompt(nurse);
   }
 
-  public addUser(user: User) {
-    console.log('Add', user);
-    this.usersCollection.add(user);
-  }
-
-  public updateUser(user: User, data) {
-    console.log('Update', { user, data });
-    this.usersCollection.doc(user.$id).update(data);
-  }
-
-  public removeUser(user: User) {
-    console.log('Remove', user);
-    this.usersCollection.doc(user.$id).delete();
+  public removeNurse(nurse: Nurse) {
+    this.nurseProvider.removeNurse(nurse);
   }
 
 }

--- a/src/providers/nurse/nurse.ts
+++ b/src/providers/nurse/nurse.ts
@@ -1,0 +1,108 @@
+import { Injectable } from '@angular/core';
+import { AngularFirestore, AngularFirestoreCollection } from 'angularfire2/firestore';
+import { Nurse } from '../../models/nurse';
+import { Observable } from 'rxjs/Observable';
+import 'rxjs/Rx';
+import { AlertController } from 'ionic-angular';
+import { DocumentReference } from '@firebase/firestore-types';
+
+@Injectable()
+export class NurseProvider {
+  private nursesCollection: AngularFirestoreCollection<Nurse>;
+  private nurses: Observable<Nurse[]>;
+  private exampleRoomRef: DocumentReference;
+
+  constructor(public fireStore: AngularFirestore, public alertCtrl: AlertController) {
+    this.exampleRoomRef = fireStore.doc('rooms/exampleRoom').ref; // Temporary example reference
+    this.nursesCollection = fireStore.collection<Nurse>('/nurses');
+
+    this.nurses = this.nursesCollection.snapshotChanges().map((actions) => actions.map((nurseAction) => {
+      const data = nurseAction.payload.doc.data() as Nurse;
+      const $id = nurseAction.payload.doc.id;
+
+      // Get the observable of the referenced Room document
+      const roomObservable = fireStore.doc(data.roomRef.path).snapshotChanges()
+        .map((action) => action.payload.data());
+
+      // Extend the Nurse object with the ID and referenced Room data
+      return roomObservable.map((room) => ({ ...data, $id, room: room.name }));
+    })).flatMap((nurses) => Observable.combineLatest(nurses));
+  }
+
+  public getNurses() {
+    return this.nurses;
+  }
+
+  // @TODO Replace static example roomRef with dynamically chosen value
+  public addNurse(nurse: Nurse) {
+    this.nursesCollection.add(nurse);
+  }
+
+  public updateNurse(nurse: Nurse, data) {
+    this.nursesCollection.doc(nurse.$id).update(data);
+  }
+
+  public removeNurse(nurse: Nurse) {
+    this.nursesCollection.doc(nurse.$id).delete();
+  }
+
+  public addNursePrompt() {
+    const prompt = this.alertCtrl.create({
+      title: 'Add Nurse',
+      message: 'Add a new nurse.',
+      inputs: [
+        {
+          name: 'name',
+          placeholder: 'Name',
+        },
+        {
+          name: 'age',
+          placeholder: 'Age',
+          type: 'number',
+        },
+      ],
+      buttons: [
+        {
+          text: 'Cancel',
+        },
+        {
+          text: 'Add',
+          handler: ({ name, age }) => this.addNurse({ name, age: +age, roomRef: this.exampleRoomRef }),
+        },
+      ],
+    });
+    prompt.present();
+  }
+
+  public updateNursePrompt(nurse: Nurse) {
+    const prompt = this.alertCtrl.create({
+      title: 'Update Nurse',
+      message: 'Update nurse data.',
+      inputs: [
+        {
+          name: 'name',
+          placeholder: nurse.name,
+        },
+        {
+          name: 'age',
+          placeholder: String(nurse.age),
+          type: 'number',
+        },
+      ],
+      buttons: [
+        {
+          text: 'Cancel',
+        },
+        {
+          text: 'Update',
+          handler: ({ name, age }) => this.updateNurse(nurse, {
+            name: name || nurse.name,
+            age: +age || nurse.age,
+          }),
+        },
+      ],
+    });
+    prompt.present();
+  }
+
+}


### PR DESCRIPTION
## Replace User functionality with Nurse provider
Updates the example Firestore functionality (see pull request #13) by extracting the functionality into a provider, for better separation of concerns and increased modularity.

The `users` collection has been replaced by `nurses`. A `nurses` collection document contains a reference to a document in the `rooms` collection. The code in this pull request contains functionality to extract the value from the referenced document, i.e. the name of the room.