### PR TITLE
Add admin tab navigation

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -3,8 +3,6 @@ import { Platform } from 'ionic-angular';
 import { StatusBar } from '@ionic-native/status-bar';
 import { SplashScreen } from '@ionic-native/splash-screen';
 import { AdminTabs } from '../pages/admin-tabs/admin-tabs';
-import { NurseListPage } from '../pages/nurse-list/nurse-list';
-import { DoctorListPage } from '../pages/doctor-list/doctor-list';
 
 @Component({
   templateUrl: 'app.html',

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -2,13 +2,15 @@ import { Component } from '@angular/core';
 import { Platform } from 'ionic-angular';
 import { StatusBar } from '@ionic-native/status-bar';
 import { SplashScreen } from '@ionic-native/splash-screen';
-import { HomePage } from '../pages/home/home';
+import { AdminTabs } from '../pages/admin-tabs/admin-tabs';
+import { NurseListPage } from '../pages/nurse-list/nurse-list';
+import { DoctorListPage } from '../pages/doctor-list/doctor-list';
 
 @Component({
   templateUrl: 'app.html',
 })
 export class MyApp {
-  public rootPage: any = HomePage;
+  public rootPage: any = AdminTabs;
 
   constructor(platform: Platform, statusBar: StatusBar, splashScreen: SplashScreen) {
     platform.ready().then(() => {

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -10,8 +10,11 @@ import { PatientPage } from '../pages/patient/patient';
 import { AddPatientPage } from '../pages/add-patient/add-patient';
 import { PatientDetailPage } from '../pages/patient-detail/patient-detail';
 import { UpdatePatientPage } from '../pages/update-patient/update-patient';
+import { NurseListPage } from '../pages/nurse-list/nurse-list';
+import { DoctorListPage } from '../pages/doctor-list/doctor-list';
 import { NurseProvider } from '../providers/nurse/nurse';
 import { LoginPage } from '../pages/login/login';
+import { AdminTabs } from '../pages/admin-tabs/admin-tabs';
 import { AngularFireModule } from 'angularfire2';
 import { AngularFireAuthModule } from 'angularfire2/auth';
 import { AngularFirestoreModule } from 'angularfire2/firestore';
@@ -28,6 +31,9 @@ import { DoctorRegistration } from '../pages/doctorRegistration/doctorRegistrati
     AddPatientPage,
     PatientDetailPage,
     UpdatePatientPage,
+    AdminTabs,
+    NurseListPage,
+    DoctorListPage,
   ],
   imports: [
     BrowserModule,
@@ -46,6 +52,9 @@ import { DoctorRegistration } from '../pages/doctorRegistration/doctorRegistrati
     AddPatientPage,
     PatientDetailPage,
     UpdatePatientPage,
+    AdminTabs,
+    NurseListPage,
+    DoctorListPage,
   ],
   providers: [
     StatusBar,

--- a/src/pages/admin-tabs/admin-tabs.html
+++ b/src/pages/admin-tabs/admin-tabs.html
@@ -1,0 +1,5 @@
+<ion-tabs>
+  <ion-tab [root]="tab1Root" tabTitle="Patients"></ion-tab>
+  <ion-tab [root]="tab2Root" tabTitle="Doctors"></ion-tab>
+  <ion-tab [root]="tab3Root" tabTitle="Nurses"></ion-tab>
+</ion-tabs>

--- a/src/pages/admin-tabs/admin-tabs.module.ts
+++ b/src/pages/admin-tabs/admin-tabs.module.ts
@@ -1,0 +1,13 @@
+import { NgModule } from '@angular/core';
+import { IonicPageModule } from 'ionic-angular';
+import { AdminTabs } from './admin-tabs';
+
+@NgModule({
+  declarations: [
+    AdminTabs,
+  ],
+  imports: [
+    IonicPageModule.forChild(AdminTabs),
+  ],
+})
+export class AdminTabsModule {}

--- a/src/pages/admin-tabs/admin-tabs.scss
+++ b/src/pages/admin-tabs/admin-tabs.scss
@@ -1,0 +1,3 @@
+page-admin-tabs {
+
+}

--- a/src/pages/admin-tabs/admin-tabs.ts
+++ b/src/pages/admin-tabs/admin-tabs.ts
@@ -1,6 +1,5 @@
 import { Component } from '@angular/core';
 import { IonicPage, NavController, NavParams } from 'ionic-angular';
-import { HomePage } from '../../pages/home/home';
 import { PatientPage } from '../../pages/patient/patient';
 import { DoctorListPage } from '../../pages/doctor-list/doctor-list';
 import { NurseListPage } from '../../pages/nurse-list/nurse-list';

--- a/src/pages/admin-tabs/admin-tabs.ts
+++ b/src/pages/admin-tabs/admin-tabs.ts
@@ -1,0 +1,19 @@
+import { Component } from '@angular/core';
+import { IonicPage, NavController, NavParams } from 'ionic-angular';
+import { HomePage } from '../../pages/home/home';
+import { PatientPage } from '../../pages/patient/patient';
+import { DoctorListPage } from '../../pages/doctor-list/doctor-list';
+import { NurseListPage } from '../../pages/nurse-list/nurse-list';
+
+@IonicPage()
+@Component({
+  selector: 'page-admin-tabs',
+  templateUrl: 'admin-tabs.html',
+})
+export class AdminTabs {
+  public tab1Root = PatientPage;
+  public tab2Root = DoctorListPage;
+  public tab3Root = NurseListPage;
+
+  constructor(public navCtrl: NavController, public navParams: NavParams) {}
+}

--- a/src/pages/doctor-list/doctor-list.html
+++ b/src/pages/doctor-list/doctor-list.html
@@ -1,0 +1,18 @@
+<!--
+  Generated template for the DoctorListPage page.
+
+  See http://ionicframework.com/docs/components/#navigation for more info on
+  Ionic pages and navigation.
+-->
+<ion-header>
+
+  <ion-navbar>
+    <ion-title>doctorList</ion-title>
+  </ion-navbar>
+
+</ion-header>
+
+
+<ion-content padding>
+
+</ion-content>

--- a/src/pages/doctor-list/doctor-list.html
+++ b/src/pages/doctor-list/doctor-list.html
@@ -1,15 +1,7 @@
-<!--
-  Generated template for the DoctorListPage page.
-
-  See http://ionicframework.com/docs/components/#navigation for more info on
-  Ionic pages and navigation.
--->
 <ion-header>
-
   <ion-navbar>
-    <ion-title>doctorList</ion-title>
+    <ion-title>Doctors</ion-title>
   </ion-navbar>
-
 </ion-header>
 
 

--- a/src/pages/doctor-list/doctor-list.module.ts
+++ b/src/pages/doctor-list/doctor-list.module.ts
@@ -1,0 +1,13 @@
+import { NgModule } from '@angular/core';
+import { IonicPageModule } from 'ionic-angular';
+import { DoctorListPage } from './doctor-list';
+
+@NgModule({
+  declarations: [
+    DoctorListPage,
+  ],
+  imports: [
+    IonicPageModule.forChild(DoctorListPage),
+  ],
+})
+export class DoctorListPageModule {}

--- a/src/pages/doctor-list/doctor-list.scss
+++ b/src/pages/doctor-list/doctor-list.scss
@@ -1,0 +1,3 @@
+page-doctor-list {
+
+}

--- a/src/pages/doctor-list/doctor-list.ts
+++ b/src/pages/doctor-list/doctor-list.ts
@@ -1,0 +1,25 @@
+import { Component } from '@angular/core';
+import { IonicPage, NavController, NavParams } from 'ionic-angular';
+
+/**
+ * Generated class for the DoctorListPage page.
+ *
+ * See https://ionicframework.com/docs/components/#navigation for more info on
+ * Ionic pages and navigation.
+ */
+
+@IonicPage()
+@Component({
+  selector: 'page-doctor-list',
+  templateUrl: 'doctor-list.html',
+})
+export class DoctorListPage {
+
+  constructor(public navCtrl: NavController, public navParams: NavParams) {
+  }
+
+  ionViewDidLoad() {
+    console.log('ionViewDidLoad DoctorListPage');
+  }
+
+}

--- a/src/pages/doctor-list/doctor-list.ts
+++ b/src/pages/doctor-list/doctor-list.ts
@@ -1,13 +1,6 @@
 import { Component } from '@angular/core';
 import { IonicPage, NavController, NavParams } from 'ionic-angular';
 
-/**
- * Generated class for the DoctorListPage page.
- *
- * See https://ionicframework.com/docs/components/#navigation for more info on
- * Ionic pages and navigation.
- */
-
 @IonicPage()
 @Component({
   selector: 'page-doctor-list',
@@ -15,11 +8,5 @@ import { IonicPage, NavController, NavParams } from 'ionic-angular';
 })
 export class DoctorListPage {
 
-  constructor(public navCtrl: NavController, public navParams: NavParams) {
-  }
-
-  ionViewDidLoad() {
-    console.log('ionViewDidLoad DoctorListPage');
-  }
-
+  constructor(public navCtrl: NavController, public navParams: NavParams) {}
 }

--- a/src/pages/nurse-list/nurse-list.html
+++ b/src/pages/nurse-list/nurse-list.html
@@ -1,0 +1,33 @@
+<ion-header>
+  <ion-navbar color="primary">
+    <ion-title>
+      Nurses
+    </ion-title>
+    <ion-buttons end>
+      <button ion-button icon-only (click)="addNursePrompt()">
+        <ion-icon name="person-add"></ion-icon>
+      </button>
+    </ion-buttons>
+  </ion-navbar>
+</ion-header>
+
+<ion-content>
+  <ion-list>
+    <ion-item-sliding #item *ngFor="let nurse of nurses | async">
+      <ion-item (click)="updateNursePrompt(nurse)">
+        <ion-avatar item-start>
+          <img src="http://i.pravatar.cc/150?u={{nurse.$id}}">
+        </ion-avatar>
+        <h2>{{nurse.name}}</h2>
+        <p>Age: {{nurse.age}}</p>
+        <p>Room: {{nurse.room}}</p>
+      </ion-item>
+      <ion-item-options side="right">
+        <button ion-button color="danger" (click)="removeNurse(nurse)">
+          <ion-icon name="trash"></ion-icon>
+          Remove
+        </button>
+      </ion-item-options>
+    </ion-item-sliding>
+  </ion-list>
+</ion-content>

--- a/src/pages/nurse-list/nurse-list.module.ts
+++ b/src/pages/nurse-list/nurse-list.module.ts
@@ -1,0 +1,13 @@
+import { NgModule } from '@angular/core';
+import { IonicPageModule } from 'ionic-angular';
+import { NurseListPage } from './nurse-list';
+
+@NgModule({
+  declarations: [
+    NurseListPage,
+  ],
+  imports: [
+    IonicPageModule.forChild(NurseListPage),
+  ],
+})
+export class NurseListPageModule {}

--- a/src/pages/nurse-list/nurse-list.scss
+++ b/src/pages/nurse-list/nurse-list.scss
@@ -1,0 +1,3 @@
+page-nurse-list {
+
+}

--- a/src/pages/nurse-list/nurse-list.ts
+++ b/src/pages/nurse-list/nurse-list.ts
@@ -1,0 +1,30 @@
+import { Component } from '@angular/core';
+import { IonicPage, NavController } from 'ionic-angular';
+import { Nurse } from '../../models/nurse';
+import { NurseProvider } from '../../providers/nurse/nurse';
+import { Observable } from 'rxjs/Observable';
+
+@IonicPage()
+@Component({
+  selector: 'page-nurse-list',
+  templateUrl: 'nurse-list.html',
+})
+export class NurseListPage {
+  public nurses: Observable<Nurse[]>;
+
+  constructor(public navCtrl: NavController, public nurseProvider: NurseProvider) {
+    this.nurses = nurseProvider.getNurses();
+  }
+
+  public addNursePrompt() {
+    this.nurseProvider.addNursePrompt();
+  }
+
+  public updateNursePrompt(nurse: Nurse) {
+    this.nurseProvider.updateNursePrompt(nurse);
+  }
+
+  public removeNurse(nurse: Nurse) {
+    this.nurseProvider.removeNurse(nurse);
+  }
+}


### PR DESCRIPTION
# Add admin tab navigation
Adds tab navigation to the application, displaying patients, doctors, and nurses in separate tabs.

**Notes:**
Currently there is no list view of doctors, but it will be implemented in the future. This pull request contains an empty page for the doctor list.

Currently the tab navigation is set as the root view, but it will be replaced by the login view later.

**Preview:**
<img width="393" alt="screen shot 2018-04-19 at 13 31 53" src="https://user-images.githubusercontent.com/8606831/38989133-0fff6dc0-43d6-11e8-8edf-b31e20fb69d8.png">
