### PR TITLE
Distinguish comment categories by color

### DIFF
--- a/src/pages/patient-detail/patient-detail.html
+++ b/src/pages/patient-detail/patient-detail.html
@@ -34,7 +34,7 @@
     <ion-list-header>History</ion-list-header>
     <ion-item-group *ngFor="let comment of comments | async" [ngSwitch]="comment.category">
       <!-- NOTE -->
-      <ion-card *ngSwitchCase="'Note'">
+      <ion-card *ngSwitchCase="'Note'" class="info">
         <ion-card-header>{{comment.category}}</ion-card-header>
         <ion-card-content>
           <p><strong>{{comment.title}}</strong></p>
@@ -43,7 +43,7 @@
         </ion-card-content>
       </ion-card>
       <!-- TREATMENT -->
-      <ion-card *ngSwitchCase="'Treatment'">
+      <ion-card *ngSwitchCase="'Treatment'" class="success">
         <ion-card-header>{{comment.category}}</ion-card-header>
         <ion-card-content>
           <p><strong>{{comment.title}}</strong></p>
@@ -51,7 +51,7 @@
         </ion-card-content>
       </ion-card>
       <!-- DIAGNOSIS -->
-      <ion-card *ngSwitchCase="'Diagnosis'">
+      <ion-card *ngSwitchCase="'Diagnosis'" class="danger">
         <ion-card-header>Diagnosed with {{comment.title}}</ion-card-header>
         <ion-card-content>
           <p><strong>Diagnosed by </strong>Dr. xxx</p>

--- a/src/pages/patient-detail/patient-detail.scss
+++ b/src/pages/patient-detail/patient-detail.scss
@@ -1,3 +1,21 @@
 page-patient-detail {
+  $border-width: 4px;
 
+  ion-card {
+    &.danger {
+      border-left: $border-width solid color($colors, danger);
+    }
+
+    &.success {
+      border-left: $border-width solid color($colors, success);
+    }
+
+    &.info {
+      border-left: $border-width solid color($colors, info);
+    }
+
+    &.warning {
+      border-left: $border-width solid color($colors, warning);
+    }
+  }
 }

--- a/src/theme/variables.scss
+++ b/src/theme/variables.scss
@@ -36,9 +36,12 @@ $app-direction: ltr;
 $colors: (
   primary:    #488aff,
   secondary:  #32db64,
-  danger:     #f53d3d,
+  danger:     #dc3545,
   light:      #f4f4f4,
-  dark:       #222
+  dark:       #222,
+  info:       #17a2b8,
+  success:    #28a745,
+  warning:    #ffc107
 );
 
 


### PR DESCRIPTION
## Distinguish comment categories by color
Distinguishes the different comment categories (diagnosis, treatment, note), by adding a subtle border color, to quickly differentiate them.

**Screenshot preview:**
<img width="353" alt="screen shot 2018-05-03 at 13 48 44" src="https://user-images.githubusercontent.com/8606831/39575062-813f7986-4ed9-11e8-9822-e60a27fd593a.png">
