### PR TITLE
Update theme colors for badges

### DIFF
--- a/src/pages/patient-list/patient-list.html
+++ b/src/pages/patient-list/patient-list.html
@@ -25,8 +25,8 @@
         <p>Date of Birth: {{patient.dateOfBirth}} ({{utl.dob2age(patient.dateOfBirth)}} yo)</p>
         <p>Room: {{patient.roomObj.name}}</p>
         <ion-badge item-end *ngIf = "patient.severity == 0" color="light">N/A</ion-badge>
-        <ion-badge item-end *ngIf = "patient.severity == 1" color="secondary">Low</ion-badge>
-        <ion-badge item-end *ngIf = "patient.severity == 2" color="primary">Med</ion-badge>
+        <ion-badge item-end *ngIf = "patient.severity == 1" color="success">Low</ion-badge>
+        <ion-badge item-end *ngIf = "patient.severity == 2" color="warning">Med</ion-badge>
         <ion-badge item-end *ngIf = "patient.severity == 3" color="danger">High</ion-badge>
       </ion-item>
       <ion-item-options side="right">

--- a/src/theme/variables.scss
+++ b/src/theme/variables.scss
@@ -36,12 +36,12 @@ $app-direction: ltr;
 $colors: (
   primary:    #488aff,
   secondary:  #32db64,
-  danger:     #dc3545,
+  danger:     #D32F2F,
   light:      #f4f4f4,
   dark:       #222,
   info:       #17a2b8,
-  success:    #28a745,
-  warning:    #ffc107
+  success:    #43A047,
+  warning:    #F57F17
 );
 
 


### PR DESCRIPTION
## Update theme colors for badges
Updates the colors of the badges for a consistent style. Uses colors from Google Material Design.

**Preview of badges:**
<img width="353" alt="screen shot 2018-05-03 at 15 43 59" src="https://user-images.githubusercontent.com/8606831/39580222-f4c0a93e-4ee8-11e8-85e0-7a525426c7d2.png">
